### PR TITLE
Include Utils in muzak/index.rb

### DIFF
--- a/lib/muzak/index.rb
+++ b/lib/muzak/index.rb
@@ -1,5 +1,6 @@
 module Muzak
   class Index
+    include Utils
     attr_accessor :hash
 
     def self.load_index(file)
@@ -64,7 +65,7 @@ module Muzak
       begin
         @hash["artists"][artist]["albums"]
       rescue Exception => e
-        []
+        {}
       end
     end
 


### PR DESCRIPTION
This includes the Utils module in muzak/index.rb so that the `error`
functions are defined. This caused a bug where causing an error in
`albums-by-artist` or `songs-by-artist` would cause the program to quit.

This also returns an empty Hash instead of an empty Array when no artist is
found for `albums-by-artist`, so that it does not fail when the keys
method is called on it.

### Testing

Running `albums-by-artist xyz` or `songs-by-artist xyz` where xyz is an artist that does not exist in the index should not cause a fatal exception on this branch.